### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Duration of scrolling to the anchor (ms)
 Determines if the anchor element will be highlighted as defined in proper-anchor.css
 
 ### `scrollToCenter (True)`
-If true the anchor element will be positioned slightly higher than the center of the browser's window if it is not too close to the bottom of the page. Otherwise it will follow the default behaviour and be positioned at the top of the page
+The anchor element will be positioned slightly higher than the center of the browser's window on two conditions. scrollToCenter must be set to "true" and the anchor element cannot be too close to the bottom of the page. Otherwise it will follow the default behaviour and be positioned at the top of the page.
 
 ## License
 MIT License


### PR DESCRIPTION
•	Under the section 'scrollToCenter (True)' restructured the first sentence to make it an active sentence. Fixed the run-on sentence by separating it into two.
•	Changed
"If true the anchor element will be positioned slightly higher than the center of the browser's window if it is not too close to the bottom of the page" to
"The anchor element will be positioned slightly higher than the center of the browser's window on two conditions. scrollToCenter must be set to "true" and the anchor element cannot be too close to the bottom of the page."